### PR TITLE
Added automatic downloading of jython. 

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,9 @@ main: com.dmytrohoi.pyplugins.PythonLoader
 author: hedgehoi
 website: http://pyplugins.dmytrohoi.com/
 version: 0.1.0
+libraries:
+  - org.python:jython-standalone:2.7.2
+
 commands:
   pyplugins:
     description: Load, unload or reload the specified python plugins.


### PR DESCRIPTION
I just found the plugin on SpigotMC and saw you had to manually download Jython. You can use the library loading feature ([this](https://www.spigotmc.org/wiki/plugin-yml/#optional-attributes)) to automatically download Jython. I implemented that for you.

A little warning tho. I couldn't test it so you gota check it before merging