### PR TITLE
Fixes #8, #10: typo of 'executer' → 'executor'

### DIFF
--- a/src/main/resources/framework/command_executor.py
+++ b/src/main/resources/framework/command_executor.py
@@ -78,7 +78,7 @@ class PythonCommandExecutor(CommandExecutor_, TabCompleter_):
         if isfunction(command_.executor):
             return command_.executor(sender, command, label, args)
 
-        executor = getattr(self, command_.executer)
+        executor = getattr(self, command_.executor)
         return executor(sender, command, label, args)
 
     def onTabComplete(self, sender, command, alias, args):


### PR DESCRIPTION
Here is a simple typo that when fixed, should make examples work.